### PR TITLE
ASCS-169 Add applicant_id to available get resources

### DIFF
--- a/services/asc/db_tables_config.json
+++ b/services/asc/db_tables_config.json
@@ -2,7 +2,7 @@
   {
     "tableName": "saved_applications",
     "modelName": "postgres-model",
-    "additionalGetResources": ["email"],
+    "additionalGetResources": ["email", "applicant_id"],
     "selectableProps": ["*"],
     "dataRetentionPeriodType": "business",
     "dataRetentionInDays": "5"


### PR DESCRIPTION
Adding `applicant_id` to the list of available db get resources for the ASC service so that we can check new applicant IDs in a list being uploaded by a recruiter against those currently in the database (avoid duplicates).

Tested locally