### PR TITLE
ASCS-235: Update ASC saved_applications migration

### DIFF
--- a/services/asc/db_tables_config.json
+++ b/services/asc/db_tables_config.json
@@ -2,7 +2,7 @@
   {
     "tableName": "saved_applications",
     "modelName": "postgres-model",
-    "additionalGetResources": ["email", "applicant_id"],
+    "additionalGetResources": ["email"],
     "selectableProps": ["*"],
     "dataRetentionPeriodType": "business",
     "dataRetentionInDays": "5"

--- a/services/asc/migrations/20230818160728_add_job_role_column_sa.js
+++ b/services/asc/migrations/20230818160728_add_job_role_column_sa.js
@@ -1,0 +1,13 @@
+
+exports.up = function(knex) {
+  return knex.schema.table('saved_applications', table => {
+    table.string('job_role').defaultTo(null);
+    table.string('applicant_id').defaultTo(null).alter();
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table('saved_applications', table => {
+    table.dropColumn('job_role');
+  });
+};


### PR DESCRIPTION
Relates [ASCS-235](https://collaboration.homeoffice.gov.uk/jira/browse/ASCS-235)

## What?

Creating a new migration for ASC to add a `job_role` column (nullable) and make the previously non-nullable `applicant_id` column nullable.

## Why?

The business requested to add a new field to the ASC csv upload so that recruiters who do not use applicant IDs can add an identifier for each applicant. As per the pattern already established we need a new column in the `saved_applications` table to store this value. 

It is also now possible for recruiters to enter no value in the `applicant_id` field so we will also make this field nullable and default to `NULL`.

## Anything else?

This PR also removes an item from `additionalGetResources` in ASCs `default_tables_config.json`. This was part of a piece of validation that has been removed from the application since and should also be removed from this repo.
