### PR TITLE
IMB-64: Add support in IMA service for a csv_urls table

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A repo for a backend microservice for hof services to communicate with RDS instances",
   "main": "server.js",
   "engines": {
-    "node": "^20.9.0"
+    "node": ">=18.16.1"
   },
   "scripts": {
     "start": "node server.js",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A repo for a backend microservice for hof services to communicate with RDS instances",
   "main": "server.js",
   "engines": {
-    "node": ">=18.16.1"
+    "node": ">=18.19.0"
   },
   "scripts": {
     "start": "node server.js",

--- a/services/ima/db_tables_config.json
+++ b/services/ima/db_tables_config.json
@@ -6,5 +6,11 @@
     "selectableProps": ["*"],
     "dataRetentionPeriodType": "calendar",
     "dataRetentionInDays": "730"
+  },
+  {
+    "tableName": "csv_urls",
+    "modelName": "postgres-model",
+    "additionalGetResources": ["email"],
+    "selectableProps": ["*"]
   }
 ]

--- a/services/ima/db_tables_config.json
+++ b/services/ima/db_tables_config.json
@@ -2,7 +2,7 @@
   {
     "tableName": "saved_applications",
     "modelName": "postgres-model",
-    "additionalGetResources": ["uan", "date_of_birth","email","submitted_at"],
+    "additionalGetResources": ["uan", "date_of_birth", "email", "submitted_at"],
     "selectableProps": ["*"],
     "dataRetentionPeriodType": "calendar",
     "dataRetentionInDays": "730"
@@ -10,7 +10,7 @@
   {
     "tableName": "csv_urls",
     "modelName": "postgres-model",
-    "additionalGetResources": ["email"],
+    "additionalGetResources": ["created_at"],
     "selectableProps": ["*"]
   }
 ]

--- a/services/ima/db_tables_config.json
+++ b/services/ima/db_tables_config.json
@@ -11,6 +11,8 @@
     "tableName": "csv_urls",
     "modelName": "postgres-model",
     "additionalGetResources": ["created_at"],
-    "selectableProps": ["*"]
+    "selectableProps": ["*"],
+    "dataRetentionPeriodType": "calendar",
+    "dataRetentionInDays": "730"
   }
 ]

--- a/services/ima/migrations/20231208155513_create_csv_urls_table.js
+++ b/services/ima/migrations/20231208155513_create_csv_urls_table.js
@@ -1,0 +1,12 @@
+
+exports.up = function(knex) {
+  return knex.schema.createTable('csv_urls', table => {
+    table.increments();
+    table.string('url').notNullable();
+    table.timestamps(true, true);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('csv_urls');
+};


### PR DESCRIPTION
## What?

* Add migrations and config setup to create a new `csv_urls` table in the IMA DB with sequential `id` (PK), `url` and timestamp `created_at` and `updated_at` columns.
* Update node engine value in `package.json` to allow running on node >=18.19.0 (v18 last supported release).

## Why?

* `csv_urls` will hold the file-vault retrieval URLs for CSV files uploaded by caseworkers. The processing container will be able to get these URLs (either latest or a series of) in order to pull the relevant file from S3 to process out of hours.
* This is required as the size of the CSV file could get up to 100,000s of rows to validate and process into the DB. Doing this by cron job at a low traffic time is better for performance and less likely to cause issues for users of the main form.
* The latest file URL added should be easily retrievable by requesting the largest sequential `id` in the table - this should correspond to the URL record that was most recently created by timestamp.
* A series of URLs should be retrievable by requesting all records that stamp `created_at` on a certain day or period of time.
* The table allows the `created_at` column in the table as an additional GET resource (on top of the incremental `id` column) as it may be useful to be able to retrieve URL records by a certain time period of creation.
* Data retention period is not necessary but currently follows the main `saved_applications` table value of 730 days.
* Allowed >=18.19 node versions to run app as HOF is mostly running 18 for services.

## Anything else?

For the full solution we will also need to set an additional flag on each user's row entered in the DB via CSV. This will require an extra column in the `saved_applications` table which can be used in the form to judge whether or not a user must answer certain form questions/fields.

This requirement is not 100% certain and relates more to actual creation of records - something that will be done by a different processing service. As such have left any updates related to this out of this PR and focus solely on providing the file-vault link as a stored value.