### PR TITLE
IMB-64 Make url column accept up to 500 characters in migration

### DIFF
--- a/services/ima/migrations/20231208155513_create_csv_urls_table.js
+++ b/services/ima/migrations/20231208155513_create_csv_urls_table.js
@@ -2,7 +2,7 @@
 exports.up = function(knex) {
   return knex.schema.createTable('csv_urls', table => {
     table.increments();
-    table.string('url').notNullable();
+    table.string('url', 500).notNullable();
     table.timestamps(true, true);
   });
 };


### PR DESCRIPTION
# What? 

Makes the migration adding the `csv_urls` table accept up to 500 characters in its `url` column (currently VARCHAR, 255) fields.
Updated the original migration created in #19 rather than making a new one. 

# Why?

* Filevault URLs are typically above the default of 255 chars in length (more like 300-350 depending on environment), so upped the limit to cope with that. 500 seems a reasonable limit as it does not allow for any large length of data but does allow some variation in file-vault link lengths.
* Localhost URLs are just under the 255 char limit so this issue was not spotted during development and was only realised in branch env testing.
* As the `csv_urls` table is not yet in use/test it can be rolled back and re-migrated in a new deploy to keep things tidy rather than adding a new migration just to cover this change. 