### PR TITLE
IMB-144: Add db migration for cepr_lookup table

### DIFF
--- a/services/ima/db_tables_config.json
+++ b/services/ima/db_tables_config.json
@@ -14,5 +14,13 @@
     "selectableProps": ["*"],
     "dataRetentionPeriodType": "calendar",
     "dataRetentionInDays": "730"
+  },
+  {
+    "tableName": "cepr_lookup",
+    "modelName": "postgres-model",
+    "additionalGetResources": ["cepr", "dob", "dtr"],
+    "selectableProps": ["*"],
+    "dataRetentionPeriodType": "calendar",
+    "dataRetentionInDays": "730"
   }
 ]

--- a/services/ima/migrations/20240418094037_create_cepr_lookup.js
+++ b/services/ima/migrations/20240418094037_create_cepr_lookup.js
@@ -1,0 +1,12 @@
+
+exports.up = function(knex) {
+  return knex.schema.createTable('cepr_lookup', table => {
+    table.string('cepr').primary();
+    table.string('dob').notNullable();
+    table.string('dtr').notNullable();
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('cepr_lookup');
+};


### PR DESCRIPTION
## What?

Added a migration to the IMA service that adds the `cepr_lookup` table to the database. 
Added necessary config to IMA service to get data and remove data from table.

## Why?

`cepr_lookup` will be used as a source of truth for users validating via CEPR and date of birth in the IMA form. This table is replaced on a nightly basis via the [hof-db-table-replacer](https://github.com/UKHomeOffice/hof-db-table-replacer). The table is separate from the saved_applications table as a validation source because the nature of the daily update to verifiable users could risk existing form progress if using the saved_applications table for the same purpose.

see [IMB-144](https://collaboration.homeoffice.gov.uk/jira/browse/IMB-144) for further details.

## How

Added functions for exports up and down. Up creates the new table and columns with constraints. Down drops the table in the case of db rollback.

## Testing

tested migration, db update script and rollback locally.