### PR TITLE
Imb 144: Remove data retention props for cepr_lookup table

### DIFF
--- a/services/ima/db_tables_config.json
+++ b/services/ima/db_tables_config.json
@@ -14,5 +14,13 @@
     "selectableProps": ["*"],
     "dataRetentionPeriodType": "calendar",
     "dataRetentionInDays": "730"
+  },
+  {
+    "tableName": "cepr_lookup",
+    "modelName": "postgres-model",
+    "additionalGetResources": ["cepr", "dob", "dtr"],
+    "selectableProps": ["*"],
+    "dataRetentionPeriodType": "calendar",
+    "dataRetentionInDays": "730"
   }
 ]

--- a/services/ima/db_tables_config.json
+++ b/services/ima/db_tables_config.json
@@ -19,8 +19,6 @@
     "tableName": "cepr_lookup",
     "modelName": "postgres-model",
     "additionalGetResources": ["cepr", "dob", "dtr"],
-    "selectableProps": ["*"],
-    "dataRetentionPeriodType": "calendar",
-    "dataRetentionInDays": "730"
+    "selectableProps": ["*"]
   }
 ]

--- a/services/ima/migrations/20240418094037_create_cepr_lookup.js
+++ b/services/ima/migrations/20240418094037_create_cepr_lookup.js
@@ -1,0 +1,12 @@
+
+exports.up = function(knex) {
+  return knex.schema.createTable('cepr_lookup', table => {
+    table.string('cepr').primary();
+    table.string('dob').notNullable();
+    table.string('dtr').notNullable();
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('cepr_lookup');
+};


### PR DESCRIPTION
## What?

Removing properties related to data retention from the cepr_lookup table.

## Why?

- The [hof-db-table-replacer](https://github.com/UKHomeOffice/hof-db-table-replacer) will be managing entires and updates to the new cepr_lookup table. There is no requirement to remove data automatically.
- There is no timestamp on rows in the cepr_lookup table, so the process will fail when attempting to remove rows by date anyway.