### PR TITLE
IMB-146: Don't add default props to SELECTS when the selectableProps is already ['*'] for a table.

### DIFF
--- a/models/postgres-model.js
+++ b/models/postgres-model.js
@@ -10,11 +10,18 @@ const DEFAULT_PROPS = [
   'updated_at'
 ];
 
+const defineSelectableProps = (tableProps, defaultProps) => {
+  if (tableProps.length === 1 && tableProps[0] === '*') {
+    return tableProps;
+  }
+  return defaultProps.concat(tableProps || []);
+}
+
 module.exports = class PostgresModel {
   constructor(tableName, selectableProps) {
     this.requestTimeout = config.requestTimeout;
     this.tableName = tableName;
-    this.selectableProps = DEFAULT_PROPS.concat(selectableProps || []);
+    this.selectableProps = defineSelectableProps(selectableProps, DEFAULT_PROPS);
   }
 
   create(props) {

--- a/models/postgres-model.js
+++ b/models/postgres-model.js
@@ -15,7 +15,7 @@ const defineSelectableProps = (tableProps, defaultProps) => {
     return tableProps;
   }
   return defaultProps.concat(tableProps || []);
-}
+};
 
 module.exports = class PostgresModel {
   constructor(tableName, selectableProps) {

--- a/services/ima/db_tables_config.json
+++ b/services/ima/db_tables_config.json
@@ -18,7 +18,7 @@
   {
     "tableName": "cepr_lookup",
     "modelName": "postgres-model",
-    "additionalGetResources": ["cepr", "dob", "dtr"],
+    "additionalGetResources": ["cepr"],
     "selectableProps": ["*"]
   }
 ]


### PR DESCRIPTION
## What?

1. Allow the postgres model to dynamically add the default props ('id', 'created_at' and 'updated_at') to a SELECT query only if the selectable props for the table have not already been set to `['*']`.

2. Removed dob and dtr from the IMA cepr_lookup table's `additionalGetResouces`.

## Why?

1. The `DEFAULT_PROPS` 'id', 'created_at' and 'updated_at' column names are automatically added to SELECT queries on  GET routes for the API. This is fine for any table that has those columns (e.g. a standard 'saved_applications), but where we want to collect data from a table that does not have these columns it will cause the query to fail while looking for them.

If the `selectableProps` configured for a table is already `['*']`then all columns will already be selected from the table including the `DEFAULT_PROPS`. As such they do not need to be added to the SELECT query for those tables that do use them. In the case where a table does not have the default props as columns it will only select those columns relevant to the table.

3. dob and dtr are not needed for any query to the IMA `cepr_lookup` table at this time so we do not need to create routes for them.

## How

Added a function to `postgres-model.js` that checks if the service specific `selectableProps` for a table is `['*']`. If all columns will be selected by this value already, do not add the `DEFAULT_PROPS` to the query.

## Testing

Tested locally running with IMA and ASC services. Will test in branch environment using the image created by this PR.

## Anything else?

See [accompanying IMA repo PR](https://github.com/UKHomeOffice/ima/pull/114) That updates behaviour to request data via the hof-rds-api requiring this update.