### PR TITLE
ACRS-39: Set up Database table for UAN/BRP Validation Process

### DIFF
--- a/services/acrs/db_tables_config.json
+++ b/services/acrs/db_tables_config.json
@@ -6,5 +6,11 @@
     "selectableProps": ["*"],
     "dataRetentionPeriodType": "calendar",
     "dataRetentionInDays": "730"
+  },
+  {
+    "tableName": "verify_lookup",
+    "modelName": "postgres-model",
+    "additionalGetResources": ["date_of_birth", "brp", "uan"],
+    "selectableProps": ["*"]
   }
 ]

--- a/services/acrs/migrations/20240502155941_add_verify_lookup_table.js
+++ b/services/acrs/migrations/20240502155941_add_verify_lookup_table.js
@@ -1,0 +1,12 @@
+
+exports.up = function(knex) {
+  return knex.schema.createTable('verify_lookup', table => {
+    table.string('date_of_birth').notNullable();
+    table.string('brp').notNullable();
+    table.string('uan').notNullable();
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('verify_lookup');
+};

--- a/services/acrs/migrations/20240502155941_add_verify_lookup_table.js
+++ b/services/acrs/migrations/20240502155941_add_verify_lookup_table.js
@@ -2,8 +2,8 @@
 exports.up = function(knex) {
   return knex.schema.createTable('verify_lookup', table => {
     table.string('date_of_birth').notNullable();
-    table.string('brp');
-    table.string('uan');
+    table.string('brp').defaultTo(null);
+    table.string('uan').defaultTo(null);
   });
 };
 

--- a/services/acrs/migrations/20240502155941_add_verify_lookup_table.js
+++ b/services/acrs/migrations/20240502155941_add_verify_lookup_table.js
@@ -2,8 +2,8 @@
 exports.up = function(knex) {
   return knex.schema.createTable('verify_lookup', table => {
     table.string('date_of_birth').notNullable();
-    table.string('brp').notNullable();
-    table.string('uan').notNullable();
+    table.string('brp');
+    table.string('uan');
   });
 };
 


### PR DESCRIPTION
## What? 

Creating a new table migration for a `verify_lookup` table that can be queried with a UAN or BRP number to confirm that the combination of UAN/BRP and a date of birth entered into the form represents a real user combination.

## Why? 

See [ACRS-39](https://collaboration.homeoffice.gov.uk/jira/browse/ACRS-39)

This behaviour acts as a sort of login to the form and stops unsolicited form submissions. Only users who can provide the UAN or BRP and date of birth of a recorded 'Referrer' in this table can continue with the form

## How? 

Add a migration to bring up and roll back the new database table.

## Testing?

Tested locally with up and down functions working ok.

## Anything Else? (optional)

The UAN and BRP fields are currently nullable as there is not confirmation that data for a Referrer will definitely always have both values to query against. This may be updated later if necessary.

## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
