### PR TITLE
ASC-323-get recruiter email by ID from recruiters

### DIFF
--- a/services/asc/db_tables_config.json
+++ b/services/asc/db_tables_config.json
@@ -10,7 +10,7 @@
   {
     "tableName": "recruiters",
     "modelName": "postgres-model",
-    "additionalGetResources": ["email"],
-    "selectableProps": ["email"]
+    "additionalGetResources": ["email", "id"],
+    "selectableProps": ["email", "id"]
   }
 ]


### PR DESCRIPTION
## What? 
update recruiters "additionalGetResources" and "selectableProps" to retrieve recruiters email from id.
## Why? 
as per ticket ASCS-323 product owner wanted to retrieve this information from database instead of user input.
## How?
I have added to `additionalGetResources` and `selectableProps` the `id`
## Testing?
n/a
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [ ] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
