### PR TITLE
HOFF-422: Automating the process of pushing tags

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -29,7 +29,7 @@ steps:
       branch:
         include:
         - master
-      event: [push, pull_request]
+      event: [push, pull_request, tag]
 
   # Trivy Security Scannner for scanning OS related vulnerabilities in Base image of Dockerfile
   - name: scan_base_image_os
@@ -50,7 +50,7 @@ steps:
       - name: dockersock
         path: /root/.dockersock
     when:
-      event: [push, pull_request]
+      event: [push, pull_request, tag]
 
   - name: setup
     <<: *node_image
@@ -58,7 +58,7 @@ steps:
       - yarn install --frozen-lockfile
     when:
       branch: master
-      event: [push, pull_request]
+      event: [push, pull_request, tag]
 
   - name: linting
     <<: *node_image
@@ -66,7 +66,7 @@ steps:
       - yarn run test:lint
     when:
       branch: master
-      event: [push, pull_request]
+      event: [push, pull_request, tag]
 
   - name: unit-tests
     <<: *node_image
@@ -74,7 +74,7 @@ steps:
       - yarn test:unit
     when:
       branch: master
-      event: [push, pull_request]
+      event: [push, pull_request, tag]
 
   - name: integration-tests
     <<: *node_image
@@ -88,7 +88,7 @@ steps:
       - yarn test:integration
     when:
       branch: master
-      event: [push, pull_request]
+      event: [push, pull_request, tag]
 
   - name: build_image
     image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/dind
@@ -100,7 +100,7 @@ steps:
         path: /var/run
     when:
       branch: master
-      event: [push, pull_request]
+      event: [push, pull_request, tag]
 
   # Trivy Security Scannner for scanning nodejs packages in Yarn
   - name: scan_node_packages
@@ -123,7 +123,7 @@ steps:
       - name: dockersock
         path: /var/run 
     when:
-      event: [push, pull_request]
+      event: [push, pull_request, tag]
 
   - name: image_to_quay
     pull: if-not-exists
@@ -138,6 +138,21 @@ steps:
     when:
       branch: master
       event: [push, pull_request]
+
+# Automatically push Docker image to Quay when a Git tag is created on the master branch, Users should reference the image using the format: image_repo_url:tag@digestsha for immutability and traceability.
+  - name: push_tag_to_quay
+    pull: if-not-exists
+    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/dind
+    environment:
+      DOCKER_PASSWORD:
+        from_secret: DOCKER_PASSWORD
+    commands:
+    - docker login -u="ukhomeofficedigital+hof_rds_api" -p=$${DOCKER_PASSWORD} quay.io
+    - docker tag $${IMAGE_REPO}:$${DRONE_COMMIT_SHA} $${IMAGE_URL}/$${IMAGE_REPO}:$${DRONE_TAG}
+    - docker push $${IMAGE_URL}/$${IMAGE_REPO}:$${DRONE_TAG}
+    when:
+      branch: master
+      event: [tag]
 
   # CRON job steps that runs security scans using Snyk & Anchore
   - name: cron_clone_repos

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Example:
 
 This repository uses Git tags to trigger the release pipeline, build container images, and push them to the Quay.io container registry.
 
-### Workflow Overview
+#### Workflow Overview
 
 Developers push a Git tag following Semantic Versioning (e.g., 1.0.0).
 
@@ -162,13 +162,13 @@ a content-addressable digest (@sha256:...)
 The complete image reference can be used in the format:
 'quay.io/yourorg/your-image:1.0.0@sha256:<digest>'
 
-### Tagging for Releases
+**Tagging for Releases**
 To release a new version, follow these steps on the master branch only:
 
-### Make sure you're on the master branch
+**Make sure you're on the master branch**
 git checkout master
 
-### Create and push a semantic version tag
+**Create and push a semantic version tag**
 git tag 1.2.3
 git push origin 1.2.3
 
@@ -178,7 +178,7 @@ Use valid Semantic Versioning format: v<MAJOR>.<MINOR>.<PATCH> (e.g., 1.0.0, 2.3
 
 The Drone CI pipeline is configured to only trigger on tags created from the master branch.
 
-### Reasong for Usage of image:tag@digest
+#### Reason for Usage of image:tag@digest
 
 The format image:tag@digest combines:
 
@@ -194,4 +194,4 @@ The digest SHA (sha256:<digest>) is a cryptographic hash that uniquely identifie
 
 'Traceability' – You can trace exactly which build and source it came from.
 
-Security – Prevents tampering or tag overwriting in registries.
+'Security' – Prevents tampering or tag overwriting in registries.

--- a/README.md
+++ b/README.md
@@ -160,15 +160,18 @@ the semantic version (e.g., 1.0.0)
 a content-addressable digest (@sha256:...)
 
 The complete image reference can be used in the format:
-'quay.io/yourorg/your-image:1.0.0@sha256:<digest>'
+**quay.io/yourorg/your-image:1.0.0@sha256:<digest>**
 
 **Tagging for Releases**
+
 To release a new version, follow these steps on the master branch only:
 
 **Make sure you're on the master branch**
+
 git checkout master
 
 **Create and push a semantic version tag**
+
 git tag 1.2.3
 git push origin 1.2.3
 

--- a/README.md
+++ b/README.md
@@ -139,3 +139,54 @@ Example:
 ```
 
 > N.B. if a database table does not have a `submitted_at` column setting the `dataRetentionFilter` for that table's config will cause a SQL query error.
+
+🏷️ Git Tags and Release Workflow
+This repository uses Git tags to trigger the release pipeline, build container images, and push them to the Quay.io container registry.
+
+🚀 Workflow Overview
+Developers push a Git tag following Semantic Versioning (e.g., 1.0.0).
+
+The Drone CI pipeline is automatically triggered only when the tag is pushed from the master branch.
+
+A Docker image is built and pushed to Quay.io.
+
+The image is tagged with:
+
+the semantic version (e.g., 1.0.0)
+
+a content-addressable digest (@sha256:...)
+
+The complete image reference can be used in the format:
+quay.io/yourorg/your-image:1.0.0@sha256:<digest>
+
+🔖 Tagging for Releases
+To release a new version, follow these steps on the master branch only:
+
+# Make sure you're on the master branch
+git checkout master
+
+# Create and push a semantic version tag
+git tag 1.2.3
+git push origin 1.2.3
+Important:
+
+Use valid Semantic Versioning format: v<MAJOR>.<MINOR>.<PATCH> (e.g., 1.0.0, 2.3.1)
+
+The Drone CI pipeline is configured to only trigger on tags created from the master branch.
+
+🧩 Why Use image:tag@digest?
+The format image:tag@digest combines:
+
+Tag (human-readable version, like 1.2.3)
+
+Digest (immutable SHA-256 content identifier)
+
+The digest SHA (sha256:<digest>) is a cryptographic hash that uniquely identifies the image content. You can retrieve it from Quay.io after the image is pushed:
+
+This guarantees:
+
+Consistency – The image always resolves to the same content.
+
+Traceability – You can trace exactly which build and source it came from.
+
+Security – Prevents tampering or tag overwriting in registries.

--- a/README.md
+++ b/README.md
@@ -140,10 +140,13 @@ Example:
 
 > N.B. if a database table does not have a `submitted_at` column setting the `dataRetentionFilter` for that table's config will cause a SQL query error.
 
-🏷️ Git Tags and Release Workflow
+
+## Git Tags and Release Workflow
+
 This repository uses Git tags to trigger the release pipeline, build container images, and push them to the Quay.io container registry.
 
-🚀 Workflow Overview
+### Workflow Overview
+
 Developers push a Git tag following Semantic Versioning (e.g., 1.0.0).
 
 The Drone CI pipeline is automatically triggered only when the tag is pushed from the master branch.
@@ -157,24 +160,26 @@ the semantic version (e.g., 1.0.0)
 a content-addressable digest (@sha256:...)
 
 The complete image reference can be used in the format:
-quay.io/yourorg/your-image:1.0.0@sha256:<digest>
+'quay.io/yourorg/your-image:1.0.0@sha256:<digest>'
 
-🔖 Tagging for Releases
+### Tagging for Releases
 To release a new version, follow these steps on the master branch only:
 
-# Make sure you're on the master branch
+### Make sure you're on the master branch
 git checkout master
 
-# Create and push a semantic version tag
+### Create and push a semantic version tag
 git tag 1.2.3
 git push origin 1.2.3
-Important:
+
+**Important:**
 
 Use valid Semantic Versioning format: v<MAJOR>.<MINOR>.<PATCH> (e.g., 1.0.0, 2.3.1)
 
 The Drone CI pipeline is configured to only trigger on tags created from the master branch.
 
-🧩 Why Use image:tag@digest?
+### Reasong for Usage of image:tag@digest
+
 The format image:tag@digest combines:
 
 Tag (human-readable version, like 1.2.3)
@@ -183,10 +188,10 @@ Digest (immutable SHA-256 content identifier)
 
 The digest SHA (sha256:<digest>) is a cryptographic hash that uniquely identifies the image content. You can retrieve it from Quay.io after the image is pushed:
 
-This guarantees:
+**This guarantees:**
 
-Consistency – The image always resolves to the same content.
+'Consistency' – The image always resolves to the same content.
 
-Traceability – You can trace exactly which build and source it came from.
+'Traceability' – You can trace exactly which build and source it came from.
 
 Security – Prevents tampering or tag overwriting in registries.

--- a/README.md
+++ b/README.md
@@ -175,6 +175,32 @@ git checkout master
 git tag 1.2.3
 git push origin 1.2.3
 
+**Alternatively,** We can create Tags from Git Hosting UI instead of CLI commands
+
+We can also create tags directly from Git hosting provider’s web interface e.g., GitHub
+
+Go to the Releases or Tags section of the repository
+
+Click "Create a new release" or "Add tag"
+
+Use the proper version format (e.g., 1.2.3) and make sure it points to the master branch
+
+This is a convenient way for team members to trigger a release without using the command line.
+
+
+###  Release Tagging Guidelines for Contributors
+
+When creating a new Git tag (either via CLI or Git UI), please follow these practices to ensure clear, traceable, and production-ready releases:
+
+Attach release notes or changelogs to a tag
+
+Link to issues, PRs, and milestones
+
+Create pre-releases for testing before full deployment
+
+This turns a simple tag into a full-fledged release artifact.
+
+
 **Important:**
 
 Use valid Semantic Versioning format: v<MAJOR>.<MINOR>.<PATCH> (e.g., 1.0.0, 2.3.1)


### PR DESCRIPTION
## What? 

* Automate Quay image push on tag and add digest usage guidance
* Added a Drone CI step to automatically push Docker images to Quay when a Git tag is created on the master branch.
* Included a note encouraging users to reference images using the format image_repo_url:tag@digestsha for immutability and traceability.

## Why? 

* Effective usage of git tags. As Git tags is used to provide a clear, traceable, and meaningful reference to specific points in your project's history—typically used for marking releases or important milestones.
* We believe this is essential to understand the tags and their reference from git 
* Tags point to a specific commit, ensuring that the codebase for a release is fixed and traceable.
* Combined with Docker image digests (image:tag@sha256:...), they ensure reproducibility.


## How? 
* Add necessary Drone steps to push tags
* Also ensure all the steps that are dependent are running on event of tag


## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [ ] I have created a JIRA number for my branch
- [ ] I have created a JIRA number for my commit
- [ ] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure drone builds are green especially tests
- [ ] I will squash the commits before merging
