### PR TITLE
CSL-229: protect migrated legacy applicant_ids with sequence update

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hof-rds-api",
-  "version": "1.1.0",
+  "version": "3.1.2",
   "description": "A repo for a backend microservice for hof services to communicate with RDS instances",
   "main": "server.js",
   "engines": {

--- a/services/csl/migrations/20250613160519_set-protect-sequence.js
+++ b/services/csl/migrations/20250613160519_set-protect-sequence.js
@@ -1,0 +1,5 @@
+exports.up = async (knex) => {
+  return await knex.schema.raw(`ALTER SEQUENCE applicants_applicant_id_seq RESTART WITH 20000`);
+};
+
+exports.down = function() {};

--- a/services/csl/migrations/20250613160519_set-protect-sequence.js
+++ b/services/csl/migrations/20250613160519_set-protect-sequence.js
@@ -1,5 +1,5 @@
 exports.up = async (knex) => {
-  return await knex.schema.raw(`ALTER SEQUENCE applicants_applicant_id_seq RESTART WITH 20000`);
+  return await knex.schema.raw('ALTER SEQUENCE applicants_applicant_id_seq RESTART WITH 20000');
 };
 
 exports.down = function() {};


### PR DESCRIPTION
## What? 

Added a new migration to CSL service that alters the sequence of the `applicants` table to begin incrementing from `applicant_id` 20000.

This is added as a new migration that can be run on existing set up CSL databases.

## Why? 

As part of the CSL go-live we will be [migrating users from the legacy database](https://collaboration.homeoffice.gov.uk/jira/browse/CSL-229). These users already have IDs in the range 0 - 10000 that should be the same in the CSL `applicants` table. This migration jumps incrementation of new users to begin at 20000 and protects ids up to 20000 to avoid duplicating IDs in the migration.

## Testing?

tested migration locally and sequence is updated

## Anything Else? (optional)

No `down` functionality for `knex` as moving the sequence backwards to any point could cause issues with existing users.

Updated the version stated in `package.json` to match that in git tags - see this as patch version so if merged `v3.1.2`.

## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
