### PR TITLE
ASCS-685 different sla for internal and external recruiters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 yarn-error.log
 .nyc_output
 .DS_Store
+.idea

--- a/README.md
+++ b/README.md
@@ -140,6 +140,62 @@ Example:
 
 > N.B. if a database table does not have a `submitted_at` column setting the `dataRetentionFilter` for that table's config will cause a SQL query error.
 
+### ASC Retention (Set & Deletion)
+
+The ASC service uses dual retention windows for the `saved_applications` table, partitioned by submission status and anchored to different dates:
+
+- Unsubmitted: 5 business days from `created_at`.
+- Submitted: 30 business days from `submitted_at`.
+
+Configuration (services/asc/db_tables_config.json):
+
+```json
+[
+  {
+    "tableName": "saved_applications",
+    "modelName": "postgres-model",
+    "additionalGetResources": ["email"],
+    "selectableProps": ["*"],
+    "customCronJobs": [
+      {
+        "tableName": "saved_applications",
+        "dataRetentionPeriodType": "business",
+        "dataRetentionInDays": "5",
+        "dataRetentionFilter": "unsubmitted",
+        "dataRetentionDateType": "created_at"
+      },
+      {
+        "tableName": "saved_applications",
+        "dataRetentionPeriodType": "business",
+        "dataRetentionInDays": "30",
+        "dataRetentionFilter": "submitted",
+        "dataRetentionDateType": "submitted_at"
+      }
+    ]
+  }
+]
+```
+
+behaviour:
+
+- Set (POST):
+  - If `submitted_at` is absent or `null`: response `expires_at` = 5 business days from `created_at`.
+  - If `submitted_at` is present (ISO string): response `expires_at` = 30 business days from `submitted_at`.
+  - Note: `expires_at` is computed for the API response; it is not persisted.
+
+- Read/Update (GET/PATCH):
+  - Response includes computed `expires_at` following the same rules; no DB writes occur.
+
+- Deletion (Cron):
+  - `dataRetentionFilter: "unsubmitted"` job removes records older than 5 business days, anchored at `created_at`.
+  - `dataRetentionFilter: "submitted"` job removes records older than 30 business days, anchored at `submitted_at`.
+
+Client contract:
+
+- To move a record into the 30-day window, include `submitted_at` as an ISO timestamp (`new Date().toISOString()`).
+- If `submitted_at` is omitted or `null`, the record remains in the 5-day unsubmitted window.
+- Business-day calculations include UK bank holidays from `data/bank_holidays.json`.
+
 
 ## Git Tags and Release Workflow
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Example:
 
 > N.B. if a database table does not have a `submitted_at` column setting the `dataRetentionFilter` for that table's config will cause a SQL query error.
 
-### ASC Retention (Set & Deletion)
+### ASC / BFIC (Border Force Integrity Check) Retention (Set & Deletion)
 
 The ASC service uses dual retention windows for the `saved_applications` table, partitioned by submission status and anchored to different dates:
 

--- a/router.js
+++ b/router.js
@@ -3,11 +3,72 @@
 const DataRetentionWindowCalculator = require('./lib/data_retention_window_calculator');
 const { clearExpired } = require('./db');
 
-const setExpiryToRecords = (records, days, type) => {
+/**
+ * Compute and attach an `expires_at` value to each record based on retention rules.
+ *
+ * Why this exists (and why it changed):
+ * - Previously, expiry was a single window anchored at `created_at` for all records:
+ *   setExpiryToRecords(records, days, type) → expiry = created_at + window.
+ * - ASC now requires dual retention windows that depend on submission status and anchor date:
+ *   - Unsubmitted → 5 business days from `created_at`.
+ *   - Submitted → 30 business days from `submitted_at`.
+ * - Those windows are driven by per-table `customCronJobs` and must mirror the scheduler's deletion logic.
+ * - This helper therefore selects the appropriate window per record and anchors to created_at/submitted_at accordingly.
+ *
+ * Parameters:
+ * - records: Array of DB rows to enrich with `expires_at`.
+ * - defaultDays/defaultType: Optional root table defaults when no matching custom job exists.
+ * - customCronJobs: Optional array of job configs (e.g., for ASC submitted/unsubmitted windows).
+ *
+ * Behaviour:
+ * - If record has `submitted_at` and a matching "submitted" job exists, use that job and anchor at `submitted_at`.
+ * - Else if record is unsubmitted and an "unsubmitted" job exists, use that job and anchor at `created_at`.
+ * - Else, fall back to defaults and anchor to `submitted_at` when present, otherwise `created_at`.
+ * - If days/type/anchor cannot be resolved, the record is returned unchanged.
+ */
+const setExpiryToRecords = (
+  records,
+  defaultDays,
+  defaultType,
+  customCronJobs
+) => {
   const calc = new DataRetentionWindowCalculator();
 
+  const findJob = filter => {
+    if (!Array.isArray(customCronJobs)) {
+      return null;
+    }
+    return customCronJobs.find(job => job.dataRetentionFilter === filter);
+  };
+
+  const submittedJob = findJob('submitted');
+  const unsubmittedJob = findJob('unsubmitted');
+
   return records.map(record => {
-    const expiry = calc.getRetentionEndDate(days, type, record.created_at);
+    const isSubmitted = Boolean(record.submitted_at);
+
+    let days = defaultDays;
+    let type = defaultType;
+    let anchorDate = record.created_at;
+
+    if (isSubmitted && submittedJob) {
+      days = parseInt(submittedJob.dataRetentionInDays, 10) || days;
+      type = submittedJob.dataRetentionPeriodType || type;
+      anchorDate = record.submitted_at;
+    } else if (!isSubmitted && unsubmittedJob) {
+      days = parseInt(unsubmittedJob.dataRetentionInDays, 10) || days;
+      type = unsubmittedJob.dataRetentionPeriodType || type;
+      anchorDate = record.created_at;
+    } else if (isSubmitted) {
+      // fall back to default window
+      anchorDate = record.submitted_at;
+    }
+
+    if (!days || !type || !anchorDate) {
+      return record;
+    }
+
+    const expiry = calc.getRetentionEndDate(days, type, anchorDate);
     record.expires_at = expiry;
     return record;
   });
@@ -27,7 +88,8 @@ module.exports = (app, props) => {
     additionalGetResources,
     selectableProps,
     dataRetentionInDays,
-    dataRetentionPeriodType
+    dataRetentionPeriodType,
+    customCronJobs
   } = props;
 
   const Model = require(`./models/${modelName}`);
@@ -37,15 +99,22 @@ module.exports = (app, props) => {
     if (!req.query.timestamp || !req.query.from) {
       return res.send({
         status: 400,
-        message: "Please add a 'timestamp' (column name) and 'from' query to your request"
+        message:
+          "Please add a 'timestamp' (column name) and 'from' query to your request"
       });
     }
-    return model.getInTimeRange(req.query)
+    return model
+      .getInTimeRange(req.query)
       .then(result => {
         let records = result;
 
-        if (dataRetentionInDays) {
-          records = setExpiryToRecords(records, dataRetentionInDays, dataRetentionPeriodType);
+        if (dataRetentionInDays || customCronJobs) {
+          records = setExpiryToRecords(
+            records,
+            dataRetentionInDays,
+            dataRetentionPeriodType,
+            customCronJobs
+          );
         }
         return res.json(records);
       })
@@ -53,7 +122,8 @@ module.exports = (app, props) => {
   });
 
   app.get(`/${tableName}/metrics`, (req, res, next) => {
-    return model.getMetrics(req.query)
+    return model
+      .getMetrics(req.query)
       .then(result => {
         return res.json(result);
       })
@@ -61,12 +131,18 @@ module.exports = (app, props) => {
   });
 
   app.get(`/${tableName}/:id`, (req, res, next) => {
-    return model.get({ id: req.params.id })
+    return model
+      .get({ id: req.params.id })
       .then(result => {
         let records = result;
 
-        if (dataRetentionInDays) {
-          records = setExpiryToRecords(records, dataRetentionInDays, dataRetentionPeriodType);
+        if (dataRetentionInDays || customCronJobs) {
+          records = setExpiryToRecords(
+            records,
+            dataRetentionInDays,
+            dataRetentionPeriodType,
+            customCronJobs
+          );
         }
         return res.json(records);
       })
@@ -76,12 +152,18 @@ module.exports = (app, props) => {
   if (additionalGetResources) {
     additionalGetResources.forEach(resource => {
       app.get(`/${tableName}/${resource}/:${resource}`, (req, res, next) => {
-        return model.get({ [resource]: decodeParam(resource, req.params[resource]) })
+        return model
+          .get({ [resource]: decodeParam(resource, req.params[resource]) })
           .then(result => {
             let records = result;
 
-            if (dataRetentionInDays) {
-              records = setExpiryToRecords(records, dataRetentionInDays, dataRetentionPeriodType);
+            if (dataRetentionInDays || customCronJobs) {
+              records = setExpiryToRecords(
+                records,
+                dataRetentionInDays,
+                dataRetentionPeriodType,
+                customCronJobs
+              );
             }
             return res.json(records);
           })
@@ -91,12 +173,18 @@ module.exports = (app, props) => {
   }
 
   app.post(`/${tableName}`, (req, res, next) => {
-    return model.create(req.body)
+    return model
+      .create(req.body)
       .then(result => {
         let records = result;
 
-        if (dataRetentionInDays) {
-          records = setExpiryToRecords(records, dataRetentionInDays, dataRetentionPeriodType);
+        if (dataRetentionInDays || customCronJobs) {
+          records = setExpiryToRecords(
+            records,
+            dataRetentionInDays,
+            dataRetentionPeriodType,
+            customCronJobs
+          );
         }
         return res.json(records);
       })
@@ -104,12 +192,18 @@ module.exports = (app, props) => {
   });
 
   app.patch(`/${tableName}/:id`, (req, res, next) => {
-    return model.patch(req.params.id, req.body)
+    return model
+      .patch(req.params.id, req.body)
       .then(result => {
         let records = result;
 
-        if (dataRetentionInDays) {
-          records = setExpiryToRecords(records, dataRetentionInDays, dataRetentionPeriodType);
+        if (dataRetentionInDays || customCronJobs) {
+          records = setExpiryToRecords(
+            records,
+            dataRetentionInDays,
+            dataRetentionPeriodType,
+            customCronJobs
+          );
         }
         return res.json(records);
       })
@@ -117,19 +211,23 @@ module.exports = (app, props) => {
   });
 
   app.delete(`/${tableName}/:id`, (req, res, next) => {
-    return model.delete(req.params.id)
+    return model
+      .delete(req.params.id)
       .then(() => {
         return res.sendStatus(200);
       })
       .catch(next);
   });
 
-  app.delete(`/${tableName}/clear/:status/:dateType/older/:days/:periodType`, (req, res, next) => {
-    const { status, dateType, days, periodType } = req.params;
-    return clearExpired(tableName, days, periodType, status, dateType)
-      .then(() => {
-        return res.sendStatus(200);
-      })
-      .catch(next);
-  });
+  app.delete(
+    `/${tableName}/clear/:status/:dateType/older/:days/:periodType`,
+    (req, res, next) => {
+      const { status, dateType, days, periodType } = req.params;
+      return clearExpired(tableName, days, periodType, status, dateType)
+        .then(() => {
+          return res.sendStatus(200);
+        })
+        .catch(next);
+    }
+  );
 };

--- a/router.js
+++ b/router.js
@@ -49,19 +49,14 @@ const setExpiryToRecords = (
 
     let days = defaultDays;
     let type = defaultType;
-    let anchorDate = record.created_at;
+    const anchorDate = isSubmitted ? record.submitted_at : record.created_at;
 
     if (isSubmitted && submittedJob) {
       days = parseInt(submittedJob.dataRetentionInDays, 10) || days;
       type = submittedJob.dataRetentionPeriodType || type;
-      anchorDate = record.submitted_at;
     } else if (!isSubmitted && unsubmittedJob) {
       days = parseInt(unsubmittedJob.dataRetentionInDays, 10) || days;
       type = unsubmittedJob.dataRetentionPeriodType || type;
-      anchorDate = record.created_at;
-    } else if (isSubmitted) {
-      // fall back to default window
-      anchorDate = record.submitted_at;
     }
 
     if (!days || !type || !anchorDate) {
@@ -72,6 +67,18 @@ const setExpiryToRecords = (
     record.expires_at = expiry;
     return record;
   });
+};
+
+const applyExpiryFromRetentionRules = (
+  records,
+  dataRetentionInDays,
+  dataRetentionPeriodType,
+  customCronJobs
+) => {
+  if (dataRetentionInDays || customCronJobs) {
+    return setExpiryToRecords(records, dataRetentionInDays, dataRetentionPeriodType, customCronJobs);
+  }
+  return records;
 };
 
 const decodeParam = (type, param) => {
@@ -103,15 +110,13 @@ module.exports = (app, props) => {
       });
     }
     return model.getInTimeRange(req.query)
-      .then(result => {
-        let records = result;
-
-        if (dataRetentionInDays || customCronJobs) {
-          records = setExpiryToRecords(records, dataRetentionInDays, dataRetentionPeriodType, customCronJobs);
-        }
-        return res.json(records);
-      })
-      .catch(next);
+      .then(result =>
+        res.json(applyExpiryFromRetentionRules(
+          result,
+          dataRetentionInDays,
+          dataRetentionPeriodType,
+          customCronJobs
+        ))).catch(next);
   });
 
   app.get(`/${tableName}/metrics`, (req, res, next) => {
@@ -124,58 +129,50 @@ module.exports = (app, props) => {
 
   app.get(`/${tableName}/:id`, (req, res, next) => {
     return model.get({ id: req.params.id })
-      .then(result => {
-        let records = result;
-
-        if (dataRetentionInDays || customCronJobs) {
-          records = setExpiryToRecords(records, dataRetentionInDays, dataRetentionPeriodType, customCronJobs);
-        }
-        return res.json(records);
-      })
-      .catch(next);
+      .then(result =>
+        res.json(applyExpiryFromRetentionRules(
+          result,
+          dataRetentionInDays,
+          dataRetentionPeriodType,
+          customCronJobs
+        ))).catch(next);
   });
 
   if (additionalGetResources) {
     additionalGetResources.forEach(resource => {
       app.get(`/${tableName}/${resource}/:${resource}`, (req, res, next) => {
         return model.get({ [resource]: decodeParam(resource, req.params[resource]) })
-          .then(result => {
-            let records = result;
-
-            if (dataRetentionInDays || customCronJobs) {
-              records = setExpiryToRecords(records, dataRetentionInDays, dataRetentionPeriodType, customCronJobs);
-            }
-            return res.json(records);
-          })
-          .catch(next);
+          .then(result =>
+            res.json(applyExpiryFromRetentionRules(
+              result,
+              dataRetentionInDays,
+              dataRetentionPeriodType,
+              customCronJobs
+            ))).catch(next);
       });
     });
   }
 
   app.post(`/${tableName}`, (req, res, next) => {
     return model.create(req.body)
-      .then(result => {
-        let records = result;
-
-        if (dataRetentionInDays || customCronJobs) {
-          records = setExpiryToRecords(records, dataRetentionInDays, dataRetentionPeriodType, customCronJobs);
-        }
-        return res.json(records);
-      })
-      .catch(next);
+      .then(result =>
+        res.json(applyExpiryFromRetentionRules(
+          result,
+          dataRetentionInDays,
+          dataRetentionPeriodType,
+          customCronJobs
+        ))).catch(next);
   });
 
   app.patch(`/${tableName}/:id`, (req, res, next) => {
     return model.patch(req.params.id, req.body)
-      .then(result => {
-        let records = result;
-
-        if (dataRetentionInDays || customCronJobs) {
-          records = setExpiryToRecords(records, dataRetentionInDays, dataRetentionPeriodType, customCronJobs);
-        }
-        return res.json(records);
-      })
-      .catch(next);
+      .then(result =>
+        res.json(applyExpiryFromRetentionRules(
+          result,
+          dataRetentionInDays,
+          dataRetentionPeriodType,
+          customCronJobs
+        ))).catch(next);
   });
 
   app.delete(`/${tableName}/:id`, (req, res, next) => {

--- a/router.js
+++ b/router.js
@@ -99,22 +99,15 @@ module.exports = (app, props) => {
     if (!req.query.timestamp || !req.query.from) {
       return res.send({
         status: 400,
-        message:
-          "Please add a 'timestamp' (column name) and 'from' query to your request"
+        message: "Please add a 'timestamp' (column name) and 'from' query to your request"
       });
     }
-    return model
-      .getInTimeRange(req.query)
+    return model.getInTimeRange(req.query)
       .then(result => {
         let records = result;
 
         if (dataRetentionInDays || customCronJobs) {
-          records = setExpiryToRecords(
-            records,
-            dataRetentionInDays,
-            dataRetentionPeriodType,
-            customCronJobs
-          );
+          records = setExpiryToRecords(records, dataRetentionInDays, dataRetentionPeriodType, customCronJobs);
         }
         return res.json(records);
       })
@@ -122,8 +115,7 @@ module.exports = (app, props) => {
   });
 
   app.get(`/${tableName}/metrics`, (req, res, next) => {
-    return model
-      .getMetrics(req.query)
+    return model.getMetrics(req.query)
       .then(result => {
         return res.json(result);
       })
@@ -131,18 +123,12 @@ module.exports = (app, props) => {
   });
 
   app.get(`/${tableName}/:id`, (req, res, next) => {
-    return model
-      .get({ id: req.params.id })
+    return model.get({ id: req.params.id })
       .then(result => {
         let records = result;
 
         if (dataRetentionInDays || customCronJobs) {
-          records = setExpiryToRecords(
-            records,
-            dataRetentionInDays,
-            dataRetentionPeriodType,
-            customCronJobs
-          );
+          records = setExpiryToRecords(records, dataRetentionInDays, dataRetentionPeriodType, customCronJobs);
         }
         return res.json(records);
       })
@@ -152,18 +138,12 @@ module.exports = (app, props) => {
   if (additionalGetResources) {
     additionalGetResources.forEach(resource => {
       app.get(`/${tableName}/${resource}/:${resource}`, (req, res, next) => {
-        return model
-          .get({ [resource]: decodeParam(resource, req.params[resource]) })
+        return model.get({ [resource]: decodeParam(resource, req.params[resource]) })
           .then(result => {
             let records = result;
 
             if (dataRetentionInDays || customCronJobs) {
-              records = setExpiryToRecords(
-                records,
-                dataRetentionInDays,
-                dataRetentionPeriodType,
-                customCronJobs
-              );
+              records = setExpiryToRecords(records, dataRetentionInDays, dataRetentionPeriodType, customCronJobs);
             }
             return res.json(records);
           })
@@ -173,18 +153,12 @@ module.exports = (app, props) => {
   }
 
   app.post(`/${tableName}`, (req, res, next) => {
-    return model
-      .create(req.body)
+    return model.create(req.body)
       .then(result => {
         let records = result;
 
         if (dataRetentionInDays || customCronJobs) {
-          records = setExpiryToRecords(
-            records,
-            dataRetentionInDays,
-            dataRetentionPeriodType,
-            customCronJobs
-          );
+          records = setExpiryToRecords(records, dataRetentionInDays, dataRetentionPeriodType, customCronJobs);
         }
         return res.json(records);
       })
@@ -192,18 +166,12 @@ module.exports = (app, props) => {
   });
 
   app.patch(`/${tableName}/:id`, (req, res, next) => {
-    return model
-      .patch(req.params.id, req.body)
+    return model.patch(req.params.id, req.body)
       .then(result => {
         let records = result;
 
         if (dataRetentionInDays || customCronJobs) {
-          records = setExpiryToRecords(
-            records,
-            dataRetentionInDays,
-            dataRetentionPeriodType,
-            customCronJobs
-          );
+          records = setExpiryToRecords(records, dataRetentionInDays, dataRetentionPeriodType, customCronJobs);
         }
         return res.json(records);
       })
@@ -211,23 +179,19 @@ module.exports = (app, props) => {
   });
 
   app.delete(`/${tableName}/:id`, (req, res, next) => {
-    return model
-      .delete(req.params.id)
+    return model.delete(req.params.id)
       .then(() => {
         return res.sendStatus(200);
       })
       .catch(next);
   });
 
-  app.delete(
-    `/${tableName}/clear/:status/:dateType/older/:days/:periodType`,
-    (req, res, next) => {
-      const { status, dateType, days, periodType } = req.params;
-      return clearExpired(tableName, days, periodType, status, dateType)
-        .then(() => {
-          return res.sendStatus(200);
-        })
-        .catch(next);
-    }
-  );
+  app.delete(`/${tableName}/clear/:status/:dateType/older/:days/:periodType`, (req, res, next) => {
+    const { status, dateType, days, periodType } = req.params;
+    return clearExpired(tableName, days, periodType, status, dateType)
+      .then(() => {
+        return res.sendStatus(200);
+      })
+      .catch(next);
+  });
 };

--- a/services/asc/db_tables_config.json
+++ b/services/asc/db_tables_config.json
@@ -4,8 +4,22 @@
     "modelName": "postgres-model",
     "additionalGetResources": ["email"],
     "selectableProps": ["*"],
-    "dataRetentionPeriodType": "business",
-    "dataRetentionInDays": "5"
+    "customCronJobs": [
+      {
+        "tableName": "saved_applications",
+        "dataRetentionPeriodType": "business",
+        "dataRetentionInDays": "5",
+        "dataRetentionFilter": "unsubmitted",
+        "dataRetentionDateType": "created_at"
+      },
+      {
+        "tableName": "saved_applications",
+        "dataRetentionPeriodType": "business",
+        "dataRetentionInDays": "30",
+        "dataRetentionFilter": "submitted",
+        "dataRetentionDateType": "submitted_at"
+      }
+    ]
   },
   {
     "tableName": "recruiters",

--- a/services/asc/migrations/20230428215725_saved_applications.js
+++ b/services/asc/migrations/20230428215725_saved_applications.js
@@ -7,6 +7,7 @@ exports.up = function(knex) {
     table.string('email').notNullable();
     table.json('session').notNullable();
     table.timestamps(true, true);
+    table.timestamp('submitted_at');
   });
 };
 

--- a/services/asc/migrations/20230428215725_saved_applications.js
+++ b/services/asc/migrations/20230428215725_saved_applications.js
@@ -7,7 +7,6 @@ exports.up = function(knex) {
     table.string('email').notNullable();
     table.json('session').notNullable();
     table.timestamps(true, true);
-    table.timestamp('submitted_at');
   });
 };
 

--- a/services/asc/migrations/20260203121500_add_submitted_at_column_sa.js
+++ b/services/asc/migrations/20260203121500_add_submitted_at_column_sa.js
@@ -1,11 +1,21 @@
 exports.up = function(knex) {
-    return knex.schema.table('saved_applications', table => {
-        table.timestamp('submitted_at').defaultTo(null);
-    });
+  return knex.schema.hasColumn('saved_applications', 'submitted_at')
+      .then(exists => {
+        if (!exists) {
+          return knex.schema.table('saved_applications', table => {
+            table.timestamp('submitted_at').nullable();
+          });
+        }
+      });
 };
 
 exports.down = function(knex) {
-    return knex.schema.table('saved_applications', table => {
-        table.dropColumn('submitted_at');
-    });
+  return knex.schema.hasColumn('saved_applications', 'submitted_at')
+      .then(exists => {
+        if (exists) {
+          return knex.schema.table('saved_applications', table => {
+            table.dropColumn('submitted_at');
+          });
+        }
+      });
 };

--- a/services/asc/migrations/20260203121500_add_submitted_at_column_sa.js
+++ b/services/asc/migrations/20260203121500_add_submitted_at_column_sa.js
@@ -1,0 +1,21 @@
+exports.up = function(knex) {
+  return knex.schema.hasColumn('saved_applications', 'submitted_at')
+    .then(exists => {
+      if (!exists) {
+        return knex.schema.table('saved_applications', table => {
+          table.timestamp('submitted_at');
+        });
+      }
+    });
+};
+
+exports.down = function(knex) {
+  return knex.schema.hasColumn('saved_applications', 'submitted_at')
+    .then(exists => {
+      if (exists) {
+        return knex.schema.table('saved_applications', table => {
+          table.dropColumn('submitted_at');
+        });
+      }
+    });
+};

--- a/services/asc/migrations/20260203121500_add_submitted_at_column_sa.js
+++ b/services/asc/migrations/20260203121500_add_submitted_at_column_sa.js
@@ -1,21 +1,11 @@
 exports.up = function(knex) {
-  return knex.schema.hasColumn('saved_applications', 'submitted_at')
-    .then(exists => {
-      if (!exists) {
-        return knex.schema.table('saved_applications', table => {
-          table.timestamp('submitted_at');
-        });
-      }
+    return knex.schema.table('saved_applications', table => {
+        table.timestamp('submitted_at').defaultTo(null);
     });
 };
 
 exports.down = function(knex) {
-  return knex.schema.hasColumn('saved_applications', 'submitted_at')
-    .then(exists => {
-      if (exists) {
-        return knex.schema.table('saved_applications', table => {
-          table.dropColumn('submitted_at');
-        });
-      }
+    return knex.schema.table('saved_applications', table => {
+        table.dropColumn('submitted_at');
     });
 };

--- a/test/_integration/asc_cron_delete.spec.js
+++ b/test/_integration/asc_cron_delete.spec.js
@@ -1,0 +1,109 @@
+'use strict';
+
+process.env.SERVICE_NAME = 'asc';
+
+const DataRetentionWindowCalculator = require('../../lib/data_retention_window_calculator');
+const DB = require('../../db').DatabaseManager;
+
+describe('ASC service - Cron deletion windows', () => {
+  let db;
+  const retentionCalculator = new DataRetentionWindowCalculator();
+
+  beforeEach(async () => {
+    db = new DB('asc', retentionCalculator);
+    await db.rollback();
+    await db.migrate();
+    await db.knex.seed.run();
+  });
+
+  afterEach(async () => {
+    await db.rollback();
+  });
+
+  it('should delete only unsubmitted records older than 5 business days (created_at)', async () => {
+    const threshold = retentionCalculator.getRetentionStartDate(
+      '5',
+      'business'
+    );
+
+    const oldDate = db.knex.raw(`TIMESTAMP '${threshold}' - INTERVAL '1 day'`);
+    const newDate = db.knex.raw(`TIMESTAMP '${threshold}' + INTERVAL '1 day'`);
+
+    // Insert two unsubmitted records: one older than threshold, one newer
+    await db.knex('saved_applications').insert([
+      {
+        applicant_id: 'D001',
+        recruiter_id: 1,
+        email: 'del30@example.com',
+        session: '{}',
+        created_at: oldDate,
+        updated_at: oldDate,
+        submitted_at: null
+      },
+      {
+        applicant_id: 'K001',
+        recruiter_id: 1,
+        email: 'keep30@example.com',
+        session: '{}',
+        created_at: newDate,
+        updated_at: newDate,
+        submitted_at: null
+      }
+    ]);
+
+    await db.deleteOldTableData();
+
+    const delRow = await db
+      .knex('saved_applications')
+      .where({ applicant_id: 'D001' });
+    const keepRow = await db
+      .knex('saved_applications')
+      .where({ applicant_id: 'K001' });
+
+    expect(delRow.length).to.eql(0);
+    expect(keepRow.length).to.eql(1);
+  });
+
+  it('should delete only submitted records older than 30 business days (submitted_at)', async () => {
+    const threshold = retentionCalculator.getRetentionStartDate(
+      '30',
+      'business'
+    );
+
+    const oldDate = db.knex.raw(`TIMESTAMP '${threshold}' - INTERVAL '1 day'`);
+    const newDate = db.knex.raw(`TIMESTAMP '${threshold}' + INTERVAL '1 day'`);
+
+    await db.knex('saved_applications').insert([
+      {
+        applicant_id: 'D005',
+        recruiter_id: 1,
+        email: 'del5@example.com',
+        session: '{}',
+        created_at: newDate, // creation irrelevant for submitted rule
+        updated_at: newDate,
+        submitted_at: oldDate
+      },
+      {
+        applicant_id: 'K005',
+        recruiter_id: 1,
+        email: 'keep5@example.com',
+        session: '{}',
+        created_at: oldDate,
+        updated_at: oldDate,
+        submitted_at: newDate
+      }
+    ]);
+
+    await db.deleteOldTableData();
+
+    const delRow = await db
+      .knex('saved_applications')
+      .where({ applicant_id: 'D005' });
+    const keepRow = await db
+      .knex('saved_applications')
+      .where({ applicant_id: 'K005' });
+
+    expect(delRow.length).to.eql(0);
+    expect(keepRow.length).to.eql(1);
+  });
+});

--- a/test/_integration/asc_cron_delete.spec.js
+++ b/test/_integration/asc_cron_delete.spec.js
@@ -5,7 +5,7 @@ process.env.SERVICE_NAME = 'asc';
 const DataRetentionWindowCalculator = require('../../lib/data_retention_window_calculator');
 const DB = require('../../db').DatabaseManager;
 
-xdescribe('ASC service - Cron deletion windows', () => {
+describe('ASC service - Cron deletion windows', () => {
   let db;
   const retentionCalculator = new DataRetentionWindowCalculator();
 

--- a/test/_integration/asc_cron_delete.spec.js
+++ b/test/_integration/asc_cron_delete.spec.js
@@ -5,7 +5,7 @@ process.env.SERVICE_NAME = 'asc';
 const DataRetentionWindowCalculator = require('../../lib/data_retention_window_calculator');
 const DB = require('../../db').DatabaseManager;
 
-describe('ASC service - Cron deletion windows', () => {
+xdescribe('ASC service - Cron deletion windows', () => {
   let db;
   const retentionCalculator = new DataRetentionWindowCalculator();
 

--- a/test/_unit/models/postgres-model.spec.js
+++ b/test/_unit/models/postgres-model.spec.js
@@ -1,0 +1,255 @@
+'use strict';
+
+const path = require('path');
+
+describe('PostgresModel', () => {
+  let proxyquire;
+
+  before(() => {
+    proxyquire = global.proxyquire;
+  });
+
+  const makeKnexFake = () => {
+    const rec = {
+      insertArgs: null,
+      insertReturningArgs: null,
+      insertIntoTable: null,
+      selectArgs: null,
+      selectFromTable: null,
+      selectWhereArgs: null,
+      selectWhereNotNullCol: null,
+      selectWhereBetween: null,
+      tableWhereArgs: null,
+      updateArgs: null,
+      updateReturningArgs: null
+    };
+
+    const insertChain = {
+      returning: args => {
+        rec.insertReturningArgs = args;
+        return insertChain;
+      },
+      into: table => {
+        rec.insertIntoTable = table;
+        return insertChain;
+      },
+      timeout: () => Promise.resolve([{ id: 1 }])
+    };
+
+    const finalChain = {
+      timeout: () => Promise.resolve([{ id: 1 }])
+    };
+
+    const selectWNChain = {
+      whereBetween: (col, range) => {
+        rec.selectWhereBetween = { col, range };
+        return finalChain;
+      }
+    };
+
+    const selectFromChain = {
+      where: props => {
+        rec.selectWhereArgs = props;
+        return finalChain;
+      },
+      whereNotNull: col => {
+        rec.selectWhereNotNullCol = col;
+        return selectWNChain;
+      },
+      whereBetween: (col, range) => {
+        rec.selectWhereBetween = { col, range };
+        return finalChain;
+      }
+    };
+
+    const selectChain = {
+      from: table => {
+        rec.selectFromTable = table;
+        return selectFromChain;
+      }
+    };
+
+    const tableChain = {
+      where: props => {
+        rec.tableWhereArgs = props;
+        return {
+          del: () => Promise.resolve(1),
+          update: fields => {
+            rec.updateArgs = fields;
+            return {
+              returning: args => {
+                rec.updateReturningArgs = args;
+                return { timeout: () => Promise.resolve([{ id: 1 }]) };
+              }
+            };
+          }
+        };
+      },
+      count: () => Promise.resolve([{ count: 0 }])
+    };
+
+    const knexFake = function (arg) {
+      if (typeof arg === 'string') {
+        return tableChain;
+      }
+
+      return tableChain;
+    };
+
+    knexFake.insert = props => {
+      rec.insertArgs = props;
+      return insertChain;
+    };
+
+    knexFake.select = args => {
+      rec.selectArgs = args;
+      return selectChain;
+    };
+
+    knexFake.fn = { now: () => 'NOW' };
+
+    knexFake.__rec = rec;
+    return knexFake;
+  };
+
+  const loadModel = (knexFake, configOverride = {}) => {
+    const Model = proxyquire(
+      path.join(process.cwd(), 'models/postgres-model.js'),
+      {
+        '../config': Object.assign(
+          { env: 'test', requestTimeout: 5000 },
+          configOverride
+        ),
+        '../knexfile.js': { test: {} },
+        knex: () => knexFake
+      }
+    );
+    return { Model, rec: knexFake.__rec };
+  };
+
+  it('should keep selectableProps as * when provided', () => {
+    const knexFake = makeKnexFake();
+    const { Model } = loadModel(knexFake);
+    const model = new Model('saved_applications', ['*']);
+    model.selectableProps.should.deep.equal(['*']);
+  });
+
+  it('should append defaults to selectableProps when not *', () => {
+    const knexFake = makeKnexFake();
+    const { Model } = loadModel(knexFake);
+    const model = new Model('saved_applications', ['email']);
+    model.selectableProps.should.deep.equal([
+      'id',
+      'created_at',
+      'updated_at',
+      'email'
+    ]);
+  });
+
+  it('should create() with provided props and return using selectableProps', async () => {
+    const knexFake = makeKnexFake();
+    const { Model, rec } = loadModel(knexFake);
+    const model = new Model('saved_applications', ['email']);
+
+    const props = { email: 'test@example.com' };
+    const result = await model.create(props);
+
+    rec.insertArgs.should.deep.equal(props);
+    rec.insertIntoTable.should.equal('saved_applications');
+    rec.insertReturningArgs.should.deep.equal([
+      'id',
+      'created_at',
+      'updated_at',
+      'email'
+    ]);
+    result.should.be.an('array');
+  });
+
+  it('should delete() by id', async () => {
+    const knexFake = makeKnexFake();
+    const { Model, rec } = loadModel(knexFake);
+    const model = new Model('saved_applications', ['*']);
+
+    await model.delete(42);
+
+    rec.tableWhereArgs.should.deep.equal({ id: 42 });
+  });
+
+  it('should get() using selectableProps and where props', async () => {
+    const knexFake = makeKnexFake();
+    const { Model, rec } = loadModel(knexFake);
+    const model = new Model('saved_applications', ['email']);
+
+    const props = { email: 'user@example.com' };
+    const rows = await model.get(props);
+
+    rec.selectArgs.should.deep.equal([
+      'id',
+      'created_at',
+      'updated_at',
+      'email'
+    ]);
+    rec.selectFromTable.should.equal('saved_applications');
+    rec.selectWhereArgs.should.deep.equal(props);
+    rows.should.be.an('array');
+  });
+
+  it('should getInTimeRange() with whereBetween only', async () => {
+    const knexFake = makeKnexFake();
+    const { Model, rec } = loadModel(knexFake);
+    const model = new Model('saved_applications', ['*']);
+
+    const q = { timestamp: 'created_at', from: '2026-02-01', to: '2026-02-05' };
+    const rows = await model.getInTimeRange(q);
+
+    rec.selectFromTable.should.equal('saved_applications');
+    rec.selectWhereBetween.should.deep.equal({
+      col: 'created_at',
+      range: ['2026-02-01', '2026-02-05']
+    });
+    rows.should.be.an('array');
+  });
+
+  it('should getInTimeRange() with whereNotNull and whereBetween', async () => {
+    const knexFake = makeKnexFake();
+    const { Model, rec } = loadModel(knexFake);
+    const model = new Model('applications', ['*']);
+
+    const q = {
+      withValue: 'submitted_at',
+      timestamp: 'submitted_at',
+      from: '2026-02-01',
+      to: '2026-02-05'
+    };
+    const rows = await model.getInTimeRange(q);
+
+    rec.selectFromTable.should.equal('applications');
+    rec.selectWhereNotNullCol.should.equal('submitted_at');
+    rec.selectWhereBetween.should.deep.equal({
+      col: 'submitted_at',
+      range: ['2026-02-01', '2026-02-05']
+    });
+    rows.should.be.an('array');
+  });
+
+  it('should patch() add updated_at and return using selectableProps', async () => {
+    const knexFake = makeKnexFake();
+    const { Model, rec } = loadModel(knexFake);
+    const model = new Model('saved_applications', ['email']);
+
+    const id = 7;
+    const props = { email: 'patched@example.com' };
+    const rows = await model.patch(id, props);
+
+    rec.tableWhereArgs.should.deep.equal({ id });
+    rec.updateArgs.should.have.property('email', 'patched@example.com');
+    rec.updateArgs.should.have.property('updated_at');
+    rec.updateReturningArgs.should.deep.equal([
+      'id',
+      'created_at',
+      'updated_at',
+      'email'
+    ]);
+    rows.should.be.an('array');
+  });
+});

--- a/test/_unit/router.spec.js
+++ b/test/_unit/router.spec.js
@@ -1,0 +1,408 @@
+'use strict';
+
+const path = require('path');
+
+describe('router expiry logic', () => {
+  let proxyquire;
+
+  before(() => {
+    proxyquire = global.proxyquire;
+  });
+
+  const StubCalc = class {
+    getRetentionEndDate(days, type, anchorDate) {
+      return `${days}|${type}|${anchorDate}`;
+    }
+  };
+
+  const buildAppHarness = () => {
+    const routes = {};
+    const app = {
+      get: (p, h) => {
+        routes[`GET ${p}`] = h;
+      },
+      post: (p, h) => {
+        routes[`POST ${p}`] = h;
+      },
+      patch: (p, h) => {
+        routes[`PATCH ${p}`] = h;
+      },
+      delete: (p, h) => {
+        routes[`DELETE ${p}`] = h;
+      }
+    };
+    return { app, routes };
+  };
+
+  const buildModelStub = records => {
+    class Model {
+      constructor() {}
+      create() {
+        return Promise.resolve(records);
+      }
+      get() {
+        return Promise.resolve(records);
+      }
+      getInTimeRange() {
+        return Promise.resolve(records);
+      }
+      patch() {
+        return Promise.resolve(records);
+      }
+      delete() {
+        return Promise.resolve();
+      }
+      getMetrics() {
+        return Promise.resolve({});
+      }
+    }
+    return Model;
+  };
+
+  const invokeRoute = async (
+    handler,
+    // eslint-disable-next-line no-unused-vars
+    method = 'POST',
+    bodyOrQuery = {},
+    params = {}
+  ) => {
+    const req = {
+      body: bodyOrQuery,
+      params,
+      query: bodyOrQuery
+    };
+    let jsonPayload;
+    const res = {
+      json: payload => {
+        jsonPayload = payload;
+      },
+      send: payload => {
+        jsonPayload = payload;
+      },
+      sendStatus: () => {}
+    };
+    const next = err => {
+      throw err;
+    };
+
+    await handler(req, res, next);
+    return jsonPayload;
+  };
+
+  it('should use 30 business days from submitted_at when submitted job exists', async () => {
+    const record = {
+      id: 1,
+      created_at: '2026-02-01T00:00:00.000Z',
+      submitted_at: '2026-02-03T00:00:00.000Z'
+    };
+
+    const ModelStub = buildModelStub([Object.assign({}, record)]);
+    const router = proxyquire(path.join(process.cwd(), 'router.js'), {
+      './lib/data_retention_window_calculator': StubCalc,
+      './models/postgres-model': ModelStub
+    });
+
+    const { app, routes } = buildAppHarness();
+    router(app, {
+      modelName: 'postgres-model',
+      tableName: 'saved_applications',
+      selectableProps: ['*'],
+      dataRetentionPeriodType: 'calendar',
+      customCronJobs: [
+        {
+          dataRetentionFilter: 'submitted',
+          dataRetentionInDays: '30',
+          dataRetentionPeriodType: 'business'
+        },
+        {
+          dataRetentionFilter: 'unsubmitted',
+          dataRetentionInDays: '5',
+          dataRetentionPeriodType: 'business'
+        }
+      ]
+    });
+
+    const handler = routes['POST /saved_applications'];
+    const payload = await invokeRoute(handler, 'POST', record);
+
+    payload.should.be.an('array');
+    payload[0].should.have.property('expires_at');
+    payload[0].expires_at.should.equal(`30|business|${record.submitted_at}`);
+  });
+
+  it('should use 5 business days from created_at when unsubmitted job exists', async () => {
+    const record = {
+      id: 2,
+      created_at: '2026-02-01T00:00:00.000Z',
+      submitted_at: null
+    };
+
+    const ModelStub = buildModelStub([Object.assign({}, record)]);
+    const router = proxyquire(path.join(process.cwd(), 'router.js'), {
+      './lib/data_retention_window_calculator': StubCalc,
+      './models/postgres-model': ModelStub
+    });
+
+    const { app, routes } = buildAppHarness();
+    router(app, {
+      modelName: 'postgres-model',
+      tableName: 'saved_applications',
+      selectableProps: ['*'],
+      customCronJobs: [
+        {
+          dataRetentionFilter: 'submitted',
+          dataRetentionInDays: '30',
+          dataRetentionPeriodType: 'business'
+        },
+        {
+          dataRetentionFilter: 'unsubmitted',
+          dataRetentionInDays: '5',
+          dataRetentionPeriodType: 'business'
+        }
+      ]
+    });
+
+    const handler = routes['POST /saved_applications'];
+    const payload = await invokeRoute(handler, 'POST', record);
+
+    payload.should.be.an('array');
+    payload[0].should.have.property('expires_at');
+    payload[0].expires_at.should.equal(`5|business|${record.created_at}`);
+  });
+
+  it('should fall back to root window when no matching custom job exists', async () => {
+    const record = {
+      id: 3,
+      created_at: '2026-02-01T00:00:00.000Z',
+      submitted_at: '2026-02-03T00:00:00.000Z'
+    };
+
+    const ModelStub = buildModelStub([Object.assign({}, record)]);
+    const router = proxyquire(path.join(process.cwd(), 'router.js'), {
+      './lib/data_retention_window_calculator': StubCalc,
+      './models/postgres-model': ModelStub
+    });
+
+    const { app, routes } = buildAppHarness();
+    router(app, {
+      modelName: 'postgres-model',
+      tableName: 'applications',
+      selectableProps: ['*'],
+      dataRetentionInDays: 10,
+      dataRetentionPeriodType: 'calendar'
+    });
+
+    const handler = routes['POST /applications'];
+    const payload = await invokeRoute(handler, 'POST', record);
+
+    payload.should.be.an('array');
+    payload[0].should.have.property('expires_at');
+    payload[0].expires_at.should.equal(`10|calendar|${record.submitted_at}`);
+  });
+
+  it('should not set expires_at when no retention config is provided', async () => {
+    const record = {
+      id: 4,
+      created_at: '2026-02-01T00:00:00.000Z'
+    };
+
+    const ModelStub = buildModelStub([Object.assign({}, record)]);
+    const router = proxyquire(path.join(process.cwd(), 'router.js'), {
+      './lib/data_retention_window_calculator': StubCalc,
+      './models/postgres-model': ModelStub
+    });
+
+    const { app, routes } = buildAppHarness();
+    router(app, {
+      modelName: 'postgres-model',
+      tableName: 'generic_table',
+      selectableProps: ['*']
+    });
+
+    const handler = routes['POST /generic_table'];
+    const payload = await invokeRoute(handler, 'POST', record);
+
+    payload.should.be.an('array');
+    payload[0].should.not.have.property('expires_at');
+  });
+
+  it('should compute expiry on GET /:id using customCronJobs (unsubmitted=5d)', async () => {
+    const record = {
+      id: 11,
+      created_at: '2026-02-01T00:00:00.000Z',
+      submitted_at: null
+    };
+
+    const ModelStub = buildModelStub([Object.assign({}, record)]);
+    const router = proxyquire(path.join(process.cwd(), 'router.js'), {
+      './lib/data_retention_window_calculator': StubCalc,
+      './models/postgres-model': ModelStub
+    });
+
+    const { app, routes } = buildAppHarness();
+    router(app, {
+      modelName: 'postgres-model',
+      tableName: 'saved_applications',
+      selectableProps: ['*'],
+      customCronJobs: [
+        {
+          dataRetentionFilter: 'unsubmitted',
+          dataRetentionInDays: '5',
+          dataRetentionPeriodType: 'business'
+        }
+      ]
+    });
+
+    const handler = routes['GET /saved_applications/:id'];
+    const payload = await invokeRoute(handler, 'GET', {}, { id: 11 });
+    payload.should.be.an('array');
+    payload[0].expires_at.should.equal(`5|business|${record.created_at}`);
+  });
+
+  it('should return 400 guidance on GET /history when query missing', async () => {
+    const ModelStub = buildModelStub([]);
+    const router = proxyquire(path.join(process.cwd(), 'router.js'), {
+      './lib/data_retention_window_calculator': StubCalc,
+      './models/postgres-model': ModelStub
+    });
+
+    const { app, routes } = buildAppHarness();
+    router(app, {
+      modelName: 'postgres-model',
+      tableName: 'saved_applications',
+      selectableProps: ['*']
+    });
+
+    const handler = routes['GET /saved_applications/history'];
+    const payload = await invokeRoute(handler, 'GET', {});
+    payload.should.have.property('status', 400);
+    payload.should.have.property('message');
+  });
+
+  it('should compute expiry on GET /history when query provided', async () => {
+    const record = { id: 12, created_at: '2026-02-01T00:00:00.000Z' };
+    const ModelStub = buildModelStub([Object.assign({}, record)]);
+    const router = proxyquire(path.join(process.cwd(), 'router.js'), {
+      './lib/data_retention_window_calculator': StubCalc,
+      './models/postgres-model': ModelStub
+    });
+
+    const { app, routes } = buildAppHarness();
+    router(app, {
+      modelName: 'postgres-model',
+      tableName: 'saved_applications',
+      selectableProps: ['*'],
+      dataRetentionInDays: 15,
+      dataRetentionPeriodType: 'calendar'
+    });
+
+    const handler = routes['GET /saved_applications/history'];
+    const payload = await invokeRoute(handler, 'GET', {
+      timestamp: 'created_at',
+      from: '2026-02-01'
+    });
+    payload.should.be.an('array');
+    payload[0].expires_at.should.equal(`15|calendar|${record.created_at}`);
+  });
+
+  it('should decode hex email and compute expiry on additional resource route (unsubmitted=5d)', async () => {
+    const record = { id: 13, created_at: '2026-02-01T00:00:00.000Z' };
+    const ModelStub = buildModelStub([Object.assign({}, record)]);
+    const router = proxyquire(path.join(process.cwd(), 'router.js'), {
+      './lib/data_retention_window_calculator': StubCalc,
+      './models/postgres-model': ModelStub
+    });
+
+    const { app, routes } = buildAppHarness();
+    router(app, {
+      modelName: 'postgres-model',
+      tableName: 'saved_applications',
+      selectableProps: ['*'],
+      additionalGetResources: ['email'],
+      customCronJobs: [
+        {
+          dataRetentionFilter: 'unsubmitted',
+          dataRetentionInDays: '5',
+          dataRetentionPeriodType: 'business'
+        }
+      ]
+    });
+
+    const hexEmail = Buffer.from('user@example.com').toString('hex');
+    const handler = routes['GET /saved_applications/email/:email'];
+    const payload = await invokeRoute(handler, 'GET', {}, { email: hexEmail });
+    payload.should.be.an('array');
+    payload[0].expires_at.should.equal(`5|business|${record.created_at}`);
+  });
+
+  it('should compute expiry on PATCH route with submitted fallback to default', async () => {
+    const record = {
+      id: 14,
+      created_at: '2026-02-01T00:00:00.000Z',
+      submitted_at: '2026-02-02T00:00:00.000Z'
+    };
+    const ModelStub = buildModelStub([Object.assign({}, record)]);
+    const router = proxyquire(path.join(process.cwd(), 'router.js'), {
+      './lib/data_retention_window_calculator': StubCalc,
+      './models/postgres-model': ModelStub
+    });
+
+    const { app, routes } = buildAppHarness();
+    router(app, {
+      modelName: 'postgres-model',
+      tableName: 'applications',
+      selectableProps: ['*'],
+      dataRetentionInDays: 10,
+      dataRetentionPeriodType: 'calendar'
+    });
+
+    const handler = routes['PATCH /applications/:id'];
+    const payload = await invokeRoute(handler, 'PATCH', record, { id: 14 });
+    payload[0].expires_at.should.equal(`10|calendar|${record.submitted_at}`);
+  });
+
+  it('should call clearExpired on DELETE /clear route with route params', async () => {
+    const ModelStub = buildModelStub([]);
+    const called = { args: null };
+    const router = proxyquire(path.join(process.cwd(), 'router.js'), {
+      './lib/data_retention_window_calculator': StubCalc,
+      './models/postgres-model': ModelStub,
+      './db': {
+        clearExpired: (...args) => {
+          called.args = args;
+          return Promise.resolve();
+        }
+      }
+    });
+
+    const { app, routes } = buildAppHarness();
+    router(app, {
+      modelName: 'postgres-model',
+      tableName: 'saved_applications',
+      selectableProps: ['*']
+    });
+
+    const handler =
+      routes[
+        'DELETE /saved_applications/clear/:status/:dateType/older/:days/:periodType'
+      ];
+    await invokeRoute(
+      handler,
+      'DELETE',
+      {},
+      {
+        status: 'unsubmitted',
+        dateType: 'created_at',
+        days: '30',
+        periodType: 'business'
+      }
+    );
+    called.args.should.deep.equal([
+      'saved_applications',
+      '30',
+      'business',
+      'unsubmitted',
+      'created_at'
+    ]);
+  });
+});


### PR DESCRIPTION
## What? 

> https://collaboration.homeoffice.gov.uk/jira/browse/ASCS-685

The ASC service uses dual retention windows for the `saved_applications` table, partitioned by submission status and anchored to different dates:

- Unsubmitted: 5 business days from `created_at`.
- Submitted: 30 business days from `submitted_at`.

## Why? 
## How? 


- Introduces dual retention windows for ASC saved_applications: 
  - unsubmitted → 5 business days from created_at 
  - submitted → 30 business days from `submitted_at`
- Aligns API expires_at computation with scheduler deletion jobs to ensure consistent lifecycle.

## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
